### PR TITLE
refactor horovod.spark.run()

### DIFF
--- a/Dockerfile.test.cpu
+++ b/Dockerfile.test.cpu
@@ -40,7 +40,7 @@ RUN if [[ "${PYTHON_VERSION}" == "3.6" ]]; then \
     fi
 RUN ln -s -f /usr/bin/python${PYTHON_VERSION} /usr/bin/python
 RUN wget https://bootstrap.pypa.io/get-pip.py && python get-pip.py && rm get-pip.py
-RUN pip install -U --force pip setuptools requests pytest
+RUN pip install -U --force pip setuptools requests pytest mock
 
 # Install PySpark.
 RUN apt install -y openjdk-8-jdk-headless

--- a/Dockerfile.test.gpu
+++ b/Dockerfile.test.gpu
@@ -47,7 +47,7 @@ RUN if [[ "${PYTHON_VERSION}" == "3.6" ]]; then \
     fi
 RUN ln -s -f /usr/bin/python${PYTHON_VERSION} /usr/bin/python
 RUN wget https://bootstrap.pypa.io/get-pip.py && python get-pip.py && rm get-pip.py
-RUN pip install -U --force pip setuptools requests pytest
+RUN pip install -U --force pip setuptools requests pytest mock
 
 # Install PySpark.
 RUN apt install -y openjdk-8-jdk-headless

--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -34,7 +34,7 @@ For example:
     $ pip install keras==2.2.4
     $ pip install torch==1.1.0 torchvision
     $ pip install pytest
-    $ pip install h5py future scipy mpi4py pyspark mxnet
+    $ pip install h5py future scipy mpi4py pyspark mock mxnet
 
 
 Build and Install

--- a/horovod/run/mpi_run.py
+++ b/horovod/run/mpi_run.py
@@ -26,6 +26,8 @@ _OMPI_FLAGS = ['-mca pml ob1', '-mca btl ^openib']
 _SMPI_FLAGS = ['-gpu', '-disable_gdr']
 # MPICH Flags
 _MPICH_FLAGS = []
+# Threshold for large cluster MPI issues:
+_LARGE_CLUSTER_THRESHOLD = 64
 
 try:
     from shlex import quote
@@ -62,7 +64,20 @@ def _get_mpi_implementation_flags():
         return None
 
 
-def mpi_run(settings, common_intfs, env, command):
+def mpi_run(settings, common_intfs, env, command, run_func=safe_shell_exec.execute):
+    """
+    Runs mpi_run.
+
+    Args:
+        settings: Settings for running MPI.
+                  Note: settings.num_hosts, settings.num_proc and settings.hosts must not be None.
+        common_intfs: Interfaces to include by MPI.
+        env: Environment dictionary to use for running MPI.
+        command: Command and arguments to run as a list of string.
+        run_func: Run function to use. Must have arguments 'command' and 'env'.
+                  Only used when settings.run_func_mode is True.
+                  Defaults to safe_shell_exec.execute.
+    """
     mpi_impl_flags = _get_mpi_implementation_flags()
     if mpi_impl_flags is None:
         raise Exception(
@@ -88,7 +103,7 @@ def mpi_run(settings, common_intfs, env, command):
         common_intfs=','.join(common_intfs)) if common_intfs else ''
 
     # On large cluster runs (e.g. Summit), we need extra settings to work around OpenMPI issues
-    if settings.num_hosts >= 64:
+    if settings.num_hosts >= _LARGE_CLUSTER_THRESHOLD:
         mpi_impl_flags.append('-mca plm_rsh_no_tree_spawn true')
         mpi_impl_flags.append('-mca plm_rsh_num_concurrent {}'.format(settings.num_proc))
 
@@ -111,7 +126,7 @@ def mpi_run(settings, common_intfs, env, command):
                 ssh_port_arg=ssh_port_arg,
                 output_filename_arg='--output-filename ' + settings.output_filename
                                     if settings.output_filename else '',
-                env=' '.join('-x %s' % key for key in env.keys()
+                env=' '.join('-x %s' % key for key in sorted(env.keys())
                              if env_util.is_exportable(key)),
 
                 extra_mpi_args=settings.extra_mpi_args if settings.extra_mpi_args else '',
@@ -123,7 +138,7 @@ def mpi_run(settings, common_intfs, env, command):
 
     # Execute the mpirun command.
     if settings.run_func_mode:
-        exit_code = safe_shell_exec.execute(mpirun_command, env=env)
+        exit_code = run_func(command=mpirun_command, env=env)
         if exit_code != 0:
             raise RuntimeError("mpirun failed with exit code {exit_code}".format(exit_code=exit_code))
     else:

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -25,7 +25,7 @@ import unittest
 import warnings
 
 import pytest
-from unittest.mock import MagicMock
+from mock import MagicMock
 
 from horovod.run.common.util import config_parser, secret, settings as hvd_settings, timeout
 from horovod.run.mpi_run import _LARGE_CLUSTER_THRESHOLD as large_cluster_threshold, mpi_run

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -18,15 +18,18 @@ from __future__ import division
 from __future__ import print_function
 
 import contextlib
+import copy
 import os
 import sys
 import unittest
 import warnings
 
 import pytest
+from unittest.mock import MagicMock
 
+from horovod.run.common.util import config_parser, secret, settings as hvd_settings, timeout
+from horovod.run.mpi_run import _LARGE_CLUSTER_THRESHOLD as large_cluster_threshold, mpi_run
 from horovod.run.run import parse_args
-from horovod.run.common.util import config_parser
 
 
 @contextlib.contextmanager
@@ -215,3 +218,100 @@ class RunTests(unittest.TestCase):
                            '--fusion-threshold-mb', '-1'):
             with pytest.raises(ValueError):
                 parse_args()
+
+    """
+    Minimal mpi_run settings for tests.
+    """
+    minimal_settings = hvd_settings.Settings(
+        verbose=0,
+        num_hosts=1,
+        num_proc=2,
+        hosts='host',
+        run_func_mode=True
+    )
+
+    """
+    Tests mpi_run with minimal settings.
+    """
+    def test_mpi_run_minimal(self):
+        cmd = ['cmd']
+        settings = self.minimal_settings
+        run_func = MagicMock(return_value=0)
+
+        mpi_run(settings, None, {}, cmd, run_func)
+
+        expected_cmd = ('mpirun '
+                        '--allow-run-as-root --tag-output '
+                        '-np 2 -H host '
+                        '-bind-to none -map-by slot '
+                        '-mca pml ob1 -mca btl ^openib       '
+                        'cmd')
+        expected_env = {}
+        run_func.assert_called_once_with(command=expected_cmd, env=expected_env)
+
+    """
+    Tests mpi_run on a large cluster.
+    """
+    def test_mpi_run_on_large_cluster(self):
+        cmd = ['cmd']
+        settings = copy.copy(self.minimal_settings)
+        settings.num_hosts = large_cluster_threshold
+        run_func = MagicMock(return_value=0)
+
+        mpi_run(settings, None, {}, cmd, run_func)
+
+        expected_cmd = ('mpirun '
+                        '--allow-run-as-root --tag-output '
+                        '-np 2 -H host '
+                        '-bind-to none -map-by slot '
+                        '-mca pml ob1 -mca btl ^openib '
+                        '-mca plm_rsh_no_tree_spawn true -mca plm_rsh_num_concurrent 2       '
+                        'cmd')
+        expected_env = {}
+        run_func.assert_called_once_with(command=expected_cmd, env=expected_env)
+
+    """
+    Tests mpi_run with full settings.
+    """
+    def test_mpi_run_full(self):
+        cmd = ['cmd', 'arg1', 'arg2']
+        common_intfs = ['eth0', 'eth1']
+        env = {'env1': 'val1', 'env2': 'val2'}
+        tmout = timeout.Timeout(5, message='Timed out waiting for something.')
+        settings = hvd_settings.Settings(
+            verbose=0,
+            ssh_port=1022,
+            extra_mpi_args='>mpi-extra args go here<',
+            key=secret.make_secret_key(),
+            timeout=tmout,
+            num_hosts=1,
+            num_proc=1,
+            hosts='>host names go here<',
+            output_filename='>output filename goes here<',
+            run_func_mode=True
+        )
+        run_func = MagicMock(return_value=0)
+
+        mpi_run(settings, common_intfs, env, cmd, run_func)
+
+        expected_cmd = ('mpirun '
+                        '--allow-run-as-root --tag-output '
+                        '-np 1 -H >host names go here< '
+                        '-bind-to none -map-by slot '
+                        '-mca pml ob1 -mca btl ^openib '
+                        '-mca plm_rsh_args "-p 1022" '
+                        '-mca btl_tcp_if_include eth0,eth1 -x NCCL_SOCKET_IFNAME=eth0,eth1 '
+                        '--output-filename >output filename goes here< '
+                        '-x env1 -x env2 '
+                        '>mpi-extra args go here< '
+                        'cmd arg1 arg2')
+        expected_env = {'env1': 'val1', 'env2': 'val2'}
+        run_func.assert_called_once_with(command=expected_cmd, env=expected_env)
+
+    def test_mpi_run_with_non_zero_exit(self):
+        cmd = ['cmd']
+        settings = self.minimal_settings
+        run_func = MagicMock(return_value=1)
+
+        with pytest.raises(RuntimeError, match="^mpirun failed with exit code 1$") as e:
+            mpi_run(settings, None, {}, cmd, run_func)

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -234,6 +234,9 @@ class RunTests(unittest.TestCase):
     Tests mpi_run with minimal settings.
     """
     def test_mpi_run_minimal(self):
+        if _get_mpi_implementation_flags() is None:
+            self.skipTest("MPI is not available")
+
         cmd = ['cmd']
         settings = self.minimal_settings
         run_func = MagicMock(return_value=0)
@@ -255,6 +258,9 @@ class RunTests(unittest.TestCase):
     Tests mpi_run on a large cluster.
     """
     def test_mpi_run_on_large_cluster(self):
+        if _get_mpi_implementation_flags() is None:
+            self.skipTest("MPI is not available")
+
         cmd = ['cmd']
         settings = copy.copy(self.minimal_settings)
         settings.num_hosts = large_cluster_threshold
@@ -279,6 +285,9 @@ class RunTests(unittest.TestCase):
     Tests mpi_run with full settings.
     """
     def test_mpi_run_full(self):
+        if _get_mpi_implementation_flags() is None:
+            self.skipTest("MPI is not available")
+
         cmd = ['cmd', 'arg1', 'arg2']
         common_intfs = ['eth0', 'eth1']
         env = {'env1': 'val1', 'env2': 'val2'}
@@ -318,6 +327,9 @@ class RunTests(unittest.TestCase):
         run_func.assert_called_once_with(command=expected_command, env=expected_env, stdout=stdout, stderr=stderr)
 
     def test_mpi_run_with_non_zero_exit(self):
+        if _get_mpi_implementation_flags() is None:
+            self.skipTest("MPI is not available")
+
         cmd = ['cmd']
         settings = self.minimal_settings
         run_func = MagicMock(return_value=1)

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -238,7 +238,7 @@ class RunTests(unittest.TestCase):
         settings = self.minimal_settings
         run_func = MagicMock(return_value=0)
 
-        mpi_run(settings, None, {}, cmd, run_func)
+        mpi_run(settings, None, {}, cmd, run_func=run_func)
 
         expected_cmd = ('mpirun '
                         '--allow-run-as-root --tag-output '
@@ -247,7 +247,7 @@ class RunTests(unittest.TestCase):
                         '-mca pml ob1 -mca btl ^openib       '
                         'cmd')
         expected_env = {}
-        run_func.assert_called_once_with(command=expected_cmd, env=expected_env)
+        run_func.assert_called_once_with(command=expected_cmd, env=expected_env, stdout=None, stderr=None)
 
     """
     Tests mpi_run on a large cluster.
@@ -258,7 +258,7 @@ class RunTests(unittest.TestCase):
         settings.num_hosts = large_cluster_threshold
         run_func = MagicMock(return_value=0)
 
-        mpi_run(settings, None, {}, cmd, run_func)
+        mpi_run(settings, None, {}, cmd, run_func=run_func)
 
         expected_cmd = ('mpirun '
                         '--allow-run-as-root --tag-output '
@@ -268,7 +268,7 @@ class RunTests(unittest.TestCase):
                         '-mca plm_rsh_no_tree_spawn true -mca plm_rsh_num_concurrent 2       '
                         'cmd')
         expected_env = {}
-        run_func.assert_called_once_with(command=expected_cmd, env=expected_env)
+        run_func.assert_called_once_with(command=expected_cmd, env=expected_env, stdout=None, stderr=None)
 
     """
     Tests mpi_run with full settings.
@@ -277,6 +277,8 @@ class RunTests(unittest.TestCase):
         cmd = ['cmd', 'arg1', 'arg2']
         common_intfs = ['eth0', 'eth1']
         env = {'env1': 'val1', 'env2': 'val2'}
+        stdout = '<stdout>'
+        stderr = '<stderr>'
         tmout = timeout.Timeout(5, message='Timed out waiting for something.')
         settings = hvd_settings.Settings(
             verbose=0,
@@ -292,7 +294,7 @@ class RunTests(unittest.TestCase):
         )
         run_func = MagicMock(return_value=0)
 
-        mpi_run(settings, common_intfs, env, cmd, run_func)
+        mpi_run(settings, common_intfs, env, cmd, stdout=stdout, stderr=stderr, run_func=run_func)
 
         expected_cmd = ('mpirun '
                         '--allow-run-as-root --tag-output '
@@ -306,7 +308,7 @@ class RunTests(unittest.TestCase):
                         '>mpi-extra args go here< '
                         'cmd arg1 arg2')
         expected_env = {'env1': 'val1', 'env2': 'val2'}
-        run_func.assert_called_once_with(command=expected_cmd, env=expected_env)
+        run_func.assert_called_once_with(command=expected_cmd, env=expected_env, stdout=stdout, stderr=stderr)
 
     def test_mpi_run_with_non_zero_exit(self):
         cmd = ['cmd']
@@ -314,4 +316,4 @@ class RunTests(unittest.TestCase):
         run_func = MagicMock(return_value=1)
 
         with pytest.raises(RuntimeError, match="^mpirun failed with exit code 1$") as e:
-            mpi_run(settings, None, {}, cmd, run_func)
+            mpi_run(settings, None, {}, cmd, run_func=run_func)

--- a/test/test_spark.py
+++ b/test/test_spark.py
@@ -98,7 +98,7 @@ class SparkTests(unittest.TestCase):
     def test_mpirun_not_found(self):
         start = time.time()
         with spark('test_mpirun_not_found'):
-            with pytest.raises(Exception, match='^mpirun exited with code 127, see the error above.$'):
+            with pytest.raises(Exception, match='^mpirun failed with exit code 127$'):
                 horovod.spark.run(None, env={'PATH': '/nonexistent'}, verbose=0)
         self.assertLessEqual(time.time() - start, 10, 'Failure propagation took too long')
 
@@ -137,7 +137,7 @@ class SparkTests(unittest.TestCase):
             return 1
 
         with spark('test_spark_run_func', cores=4):
-            with pytest.raises(Exception, match='^mpirun exited with code 1, see the error above.$') as e:
+            with pytest.raises(Exception, match='^mpirun failed with exit code 1$') as e:
                 horovod.spark.run(fn, verbose=0, run_func=run_func)
 
     """
@@ -167,8 +167,9 @@ class SparkTests(unittest.TestCase):
                               '-np {expected_np} -H [^ ]+ '
                               '-bind-to none -map-by slot '
                               r'-mca pml ob1 -mca btl \^openib  '
-                              '-mca btl_tcp_if_include [^ ]+ -x NCCL_DEBUG=INFO -x NCCL_SOCKET_IFNAME=[^ ]+ '
+                              '-mca btl_tcp_if_include [^ ]+ -x NCCL_SOCKET_IFNAME=[^ ]+  '
                               '-x _HOROVOD_SECRET_KEY {expected_env}'
+                              '-x NCCL_DEBUG=INFO '
                               r'-mca plm_rsh_agent "[^"]+python[\d]* -m horovod.spark.driver.mpirun_rsh [^ ]+ [^ ]+" '
                               r'[^"]+python[\d]* -m horovod.spark.task.mpirun_exec_fn [^ ]+ [^ ]+'
                               '$'.format(expected_np=expected_np,

--- a/test/test_spark.py
+++ b/test/test_spark.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 import contextlib
 import os
 import pytest
+import re
 import subprocess
 import time
 import torch
@@ -29,7 +30,7 @@ import warnings
 import horovod.spark
 import horovod.torch as hvd
 
-from unittest.mock import MagicMock
+from mock import MagicMock
 
 
 @contextlib.contextmanager
@@ -163,7 +164,7 @@ class SparkTests(unittest.TestCase):
                                   stdout=stdout, stderr=stderr, verbose=verbose,
                                   run_func=run_func)
 
-        self.assertNotRegex(str(e.value), '^Timed out waiting for Spark tasks to start.',
+        self.assertFalse(re.match('^Timed out waiting for Spark tasks to start.', str(e.value)),
                          'Spark timed out before mpi_run was called, test setup is broken.')
         self.assertTrue(e.match('^Spark job has failed, see the error above.$'))
 
@@ -191,7 +192,7 @@ class SparkTests(unittest.TestCase):
         actual_secret = actual_env.pop('_HOROVOD_SECRET_KEY', None)
 
         self.assertEqual(run_func_args, ())
-        self.assertRegex(actual_command, expected_cmd_regex)
+        self.assertTrue(re.match(expected_cmd_regex, actual_command))
         if env:
             self.assertEqual(actual_env, env)
         else:


### PR DESCRIPTION
- makes horovod.spark.run() use horovod.run.mpi_run() and exposes extra_mpi_args
- adds lots of tests

Please do not merge into master, only code review it.